### PR TITLE
fix(mdInput): Fix md-maxlength validation

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -404,6 +404,9 @@ function mdMaxlengthDirective($animate) {
       if (!angular.isNumber(maxlength) || maxlength < 0) {
         return true;
       }
+      if (angular.isNumber(modelValue)) {
+        modelValue = modelValue.toString();
+      }
       return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
     };
 


### PR DESCRIPTION
`mdMaxlength` currently doesn't validate properly on inputs with `type="number"`. When the `$modelValue` returns a number, its `length` property is `undefined`. This change parses the `$modelValue` to a string when it's appropriate to do so.
